### PR TITLE
fix: remove unnecessary char from gtm url

### DIFF
--- a/src/atoms/google-tag-manager/google-tag-manager.test.tsx
+++ b/src/atoms/google-tag-manager/google-tag-manager.test.tsx
@@ -13,7 +13,7 @@ describe("Google Tag Manager", () => {
   it("should render", () => {
     const wrapper = shallow(<GoogleTagManagerBase config={config} />);
     expect(wrapper.find(Analytics).prop("config")).toEqual(
-      "https://www.googletagmanager.com/amp.json?id=GTM-1234%s&gtm.url=SOURCE_URL"
+      "https://www.googletagmanager.com/amp.json?id=GTM-1234&gtm.url=SOURCE_URL"
     );
   });
   it("should have data-credentials prop", () => {

--- a/src/atoms/google-tag-manager/google-tag-manager.tsx
+++ b/src/atoms/google-tag-manager/google-tag-manager.tsx
@@ -8,7 +8,7 @@ const GoogleTagManagerBase = ({ config }) => {
 
   return (
     <Analytics
-      config={`https://www.googletagmanager.com/amp.json?id=${gtmID}%s&gtm.url=SOURCE_URL`}
+      config={`https://www.googletagmanager.com/amp.json?id=${gtmID}&gtm.url=SOURCE_URL`}
       data-credentials="include"
     />
   );


### PR DESCRIPTION
`%s` was wrongly added while migrating from sketches amp