### PR TITLE
Fix. Add width as query param for publisher logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.4.26",
+  "version": "2.4.27-amp-logo-url.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.4.26",
+  "version": "2.4.27-amp-logo-url.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/atoms/publisher-logo-header/publisher-logo-header.tsx
+++ b/src/atoms/publisher-logo-header/publisher-logo-header.tsx
@@ -38,11 +38,11 @@ export const PublisherLogoHeaderBase = ({ config, visualStoryConfig }: Publisher
       </Head>
       {logoAlignment ? (
         <div className={`logo-align-${logoAlignment}`}>
-          <amp-img alt={publisherName} src={logoUrl} layout="fill" />
+          <amp-img alt={publisherName} src={`${logoUrl}?w=512`} layout="fill" />
         </div>
       ) : (
         <a href="/">
-          <amp-img class="logo-align-center" alt={publisherName} src={logo} layout="fill" />
+          <amp-img class="logo-align-center" alt={publisherName} src={`${logo}?w=512`} layout="fill" />
         </a>
       )}
     </Fragment>

--- a/src/atoms/publisher-logo-header/publisher-logo-header.tsx
+++ b/src/atoms/publisher-logo-header/publisher-logo-header.tsx
@@ -8,7 +8,7 @@ export const PublisherLogoHeaderBase = ({ config, visualStoryConfig }: Publisher
   const publisherName = get(config, ["publisherConfig", "publisher-name"], "");
   const logo = get(config, ["ampConfig", "logo-url"], null);
   const logoAlignment = get(visualStoryConfig, ["logoAlignment"], "");
-
+  const width = 600;
   if (!logo) return null;
 
   const logoUrl = get(visualStoryConfig, ["logoUrl"], logo);
@@ -38,11 +38,11 @@ export const PublisherLogoHeaderBase = ({ config, visualStoryConfig }: Publisher
       </Head>
       {logoAlignment ? (
         <div className={`logo-align-${logoAlignment}`}>
-          <amp-img alt={publisherName} src={`${logoUrl}?w=512`} layout="fill" />
+          <amp-img alt={publisherName} src={`${logoUrl}?w=${width}`} layout="fill" />
         </div>
       ) : (
         <a href="/">
-          <amp-img class="logo-align-center" alt={publisherName} src={`${logo}?w=512`} layout="fill" />
+          <amp-img class="logo-align-center" alt={publisherName} src={`${logo}?w=${width}`} layout="fill" />
         </a>
       )}
     </Fragment>


### PR DESCRIPTION
# Description

Please include the summary of the change made. Please include the required context here. Please include the issue reference for the fix and the dependencies reference for the change.

**AMP logo url should have width param to avoid loading large images**

Fixes # (issue-reference)
https://github.com/quintype/ace-planning/issues/669

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

