### PR TITLE
Custom infinite scroll 

### DIFF
--- a/docs-src/tutorials/opts.md
+++ b/docs-src/tutorials/opts.md
@@ -29,7 +29,16 @@ const myOptsObj = {
       // ... other SE renders
     }
   },
-  featureConfig: {},
+// InfiniteScroll is powered by default with `amp-infinite-scroll` collection (there needs to be a collection created with slug `amp-infinite-scroll`. The stories from this collection power the infinite scroll)
+ // if source is `custom` - we need to provide an async function for inlineConfig & remoteConfigEndpoint
+ // if source is `relatedStoriesApi` - infiniteScroll is powered by relatedStoriesApi
+  featureConfig: {
+    infiniteScroll: {
+      source: "custom",
+      inlineConfig: async getCustomStoryList(){},
+      remoteConfigEndpoint: "/amp/api/infinite-scroll",
+    }
+  },
 };
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.4.28",
+  "version": "2.4.29-custom-infinite-scroll.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.6.0-custom-infinite-scroll.0",
+  "version": "2.6.0-custom-infinite-scroll.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.5.0",
+  "version": "2.6.0-custom-infinite-scroll.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.4.29-custom-infinite-scroll.0",
+  "version": "2.4.29-custom-infinite-scroll.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.4.28",
+  "version": "2.4.29-custom-infinite-scroll.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.6.0-custom-infinite-scroll.0",
+  "version": "2.6.0-custom-infinite-scroll.1",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.5.0",
+  "version": "2.6.0-custom-infinite-scroll.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.4.29-custom-infinite-scroll.0",
+  "version": "2.4.29-custom-infinite-scroll.1",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__fixtures__/config.fixture.tsx
+++ b/src/__fixtures__/config.fixture.tsx
@@ -641,7 +641,8 @@ export const configOpts: ConfigOpts = {
   },
   featureConfig: {
     infiniteScroll: {
-      infiniteScrollInlineConfig
+      infiniteScrollInlineConfig,
+      remoteConfigEndpoint: "https://foo.com/amp/api/infinite-scroll",
     },
     relatedStories: {
       stories: relatedStories

--- a/src/atoms/infinite-scroll/infinite-scroll.tsx
+++ b/src/atoms/infinite-scroll/infinite-scroll.tsx
@@ -17,8 +17,8 @@ export const StyledSeparator = styled.div`
 
 export const InfiniteScrollBase = ({ story, config, children, inlineConfig, ...props }: InfiniteScrollTypes) => {
   const { "story-content-id": storyId } = story;
-  const { "sketches-host": host } = config.publisherConfig;
-  const jsonConfigUrl = `${host}/amp/api/v1/amp-infinite-scroll?story-id=${storyId}`;
+  const remoteEndPoint = get(config, ["opts", "featureConfig", "infiniteScroll", "remoteConfigEndpoint"], "/amp/api/v1/amp-infinite-scroll");
+  const jsonConfigUrl = `${remoteEndPoint}?story-id=${storyId}`;
   const infiniteScrollRender = get(config, ["opts", "render", "infiniteScrollRender"], null);
   const storySeparatorText = get(
     config,

--- a/src/atoms/infinite-scroll/infinite-scroll.tsx
+++ b/src/atoms/infinite-scroll/infinite-scroll.tsx
@@ -17,7 +17,11 @@ export const StyledSeparator = styled.div`
 
 export const InfiniteScrollBase = ({ story, config, children, inlineConfig, ...props }: InfiniteScrollTypes) => {
   const { "story-content-id": storyId } = story;
-  const remoteEndPoint = get(config, ["opts", "featureConfig", "infiniteScroll", "remoteConfigEndpoint"], "/amp/api/v1/amp-infinite-scroll");
+  const remoteEndPoint = get(
+    config,
+    ["opts", "featureConfig", "infiniteScroll", "remoteConfigEndpoint"],
+    "/amp/api/v1/amp-infinite-scroll"
+  );
   const jsonConfigUrl = `${remoteEndPoint}?story-id=${storyId}`;
   const infiniteScrollRender = get(config, ["opts", "render", "infiniteScrollRender"], null);
   const storySeparatorText = get(
@@ -53,13 +57,41 @@ export const InfiniteScrollBase = ({ story, config, children, inlineConfig, ...p
 
 /**
  * Infinite Scroll:
- * In order to enable infinite scroll in amp pages, there needs to be a collection created with slug `amp-infinite-scroll`. The stories from this collection power the infinite scroll.
- * Please note that stories behind hard paywall (i.e. which have story.access === `subscription`) are not shown in infinite scroll.
- * Infinite scroll can be disabled by deleting the collection having slug `amp-infinite-scroll`.
- *
- * The text for the separator that separates two stories in an infinite scroll can be customized. Pass the text of your choice to opts.featureConfig.infiniteScroll.storySeparatorText.
- *
- * If you wish to override infinite scroll content, you can do so using the `infiniteScrollRender` render prop. See opts tutorial for more info.
+  - We can enable infinite scroll in amp pages in 3 ways:
+   - 1:  If `featureConfig > infiniteScroll > source` is `custom`
+        * then provide an async custom function for `inlineConfig` & `remoteConfigEndpoint`
+        * infiniteScroll is powered by `customFunction` response.
+      - The response should be in this format for inline configurations   
+         - `[
+         *     {
+         *       "image": "https://example.com/image.jpg",
+         *       "title": "This article shows next",
+         *      "url": "https://example.com/article.amp.html"
+         *     },
+         *     // ...
+         *     ]`
+     
+   - Remote configurations require the server to return a JSON object with the pages key/value pair.
+     - `{ pages: [
+          *  {
+          *    "image": "https://example.com/image.jpg",
+          *    "title": "This article shows next",
+          *    "url": "https://example.com/article.amp.html"
+          *  }
+         *  // ...
+        * ]
+      * }`
+      
+  * -  For more information, please go through `https://amp.dev/documentation/components/amp-next-page/`
+
+  - 2: If `featureConfig > infiniteScroll > source` is `relatedStoriesApi` - infiniteScroll is powered by `relatedStoriesApi` response.
+  - 3: If `featureConfig > infiniteScroll > source` is `not provided`, there needs to be a collection created with slug `amp-infinite-scroll`. The stories from this collection power the infinite scroll.
+ 
+  * -  Please note that stories behind hard paywall (i.e. which have story.access === `subscription`) are not shown in infinite scroll.
+  -  Infinite scroll can be disabled by deleting the collection having slug `amp-infinite-scroll`.
+  
+  * -  The text for the separator that separates two stories in an infinite scroll can be customized. Pass the text of your choice to `opts.featureConfig.infiniteScroll.storySeparatorText`.
+  -  If you wish to override infinite scroll content, you can do so using the `infiniteScrollRender` render prop. See opts tutorial for more info.
  *
  * @category Atoms
  * @module InfiniteScroll

--- a/src/atoms/subscriptions/subscriptions-paywall/__snapshots__/subscription-paywall.test.tsx.snap
+++ b/src/atoms/subscriptions/subscriptions-paywall/__snapshots__/subscription-paywall.test.tsx.snap
@@ -606,6 +606,7 @@ exports[`Subscriptions should render subscriptions 1`] = `
         "featureConfig": Object {
           "infiniteScroll": Object {
             "infiniteScrollInlineConfig": "[{\\"image\\":\\"https://foo.com/puppies.jpg\\",\\"title\\":\\"Puppies Page\\",\\"url\\":\\"/puppies\\"}]",
+            "remoteConfigEndpoint": "https://foo.com/amp/api/infinite-scroll",
           },
           "localization": Object {
             "translations": Object {

--- a/src/molecules/related-stories/__snapshots__/related-stories.test.tsx.snap
+++ b/src/molecules/related-stories/__snapshots__/related-stories.test.tsx.snap
@@ -607,6 +607,7 @@ exports[`RelatedStories should render default 1`] = `
           "featureConfig": Object {
             "infiniteScroll": Object {
               "infiniteScrollInlineConfig": "[{\\"image\\":\\"https://foo.com/puppies.jpg\\",\\"title\\":\\"Puppies Page\\",\\"url\\":\\"/puppies\\"}]",
+              "remoteConfigEndpoint": "https://foo.com/amp/api/infinite-scroll",
             },
             "localization": Object {
               "translations": Object {

--- a/src/templates/generic-story/__snapshots__/generic-story.test.tsx.snap
+++ b/src/templates/generic-story/__snapshots__/generic-story.test.tsx.snap
@@ -606,6 +606,7 @@ exports[`GenericStory Template should render 1`] = `
         "featureConfig": Object {
           "infiniteScroll": Object {
             "infiniteScrollInlineConfig": "[{\\"image\\":\\"https://foo.com/puppies.jpg\\",\\"title\\":\\"Puppies Page\\",\\"url\\":\\"/puppies\\"}]",
+            "remoteConfigEndpoint": "https://foo.com/amp/api/infinite-scroll",
           },
           "localization": Object {
             "translations": Object {

--- a/src/templates/live-blog/__snapshots__/live-blog.validation.test.tsx.snap
+++ b/src/templates/live-blog/__snapshots__/live-blog.validation.test.tsx.snap
@@ -606,6 +606,7 @@ exports[`The LiveBlog Default Template should match snapshot 1`] = `
         "featureConfig": Object {
           "infiniteScroll": Object {
             "infiniteScrollInlineConfig": "[{\\"image\\":\\"https://foo.com/puppies.jpg\\",\\"title\\":\\"Puppies Page\\",\\"url\\":\\"/puppies\\"}]",
+            "remoteConfigEndpoint": "https://foo.com/amp/api/infinite-scroll",
           },
           "localization": Object {
             "translations": Object {

--- a/src/templates/visual-story/__snapshots__/visual-story.test.tsx.snap
+++ b/src/templates/visual-story/__snapshots__/visual-story.test.tsx.snap
@@ -606,6 +606,7 @@ exports[`visual story template should match snapshot 1`] = `
         "featureConfig": Object {
           "infiniteScroll": Object {
             "infiniteScrollInlineConfig": "[{\\"image\\":\\"https://foo.com/puppies.jpg\\",\\"title\\":\\"Puppies Page\\",\\"url\\":\\"/puppies\\"}]",
+            "remoteConfigEndpoint": "https://foo.com/amp/api/infinite-scroll",
           },
           "localization": Object {
             "translations": Object {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -211,6 +211,7 @@ interface FeatureConfigTypes {
   infiniteScroll?: {
     infiniteScrollInlineConfig: string;
     storySeparatorText?: string;
+    remoteConfigEndpoint?: string;
   };
   relatedStories?: {
     stories: Story[];
@@ -246,35 +247,35 @@ interface FeatureConfigTypes {
     menuGroupSlug?: string;
   };
   visualStories?:
-    | {
-        logoAlignment?: string;
-        logoUrl?: string;
-        autoAdvanceAfter?: string;
-        ads?: {
-          doubleclick?: {
-            dataSlot: string;
-          };
+  | {
+    logoAlignment?: string;
+    logoUrl?: string;
+    autoAdvanceAfter?: string;
+    ads?: {
+      doubleclick?: {
+        dataSlot: string;
+      };
+    };
+    animation?: {
+      image: VisualStoryAnimationFeatureConfig;
+    };
+  }
+  | [
+    {
+      logoAlignment?: string;
+      logoUrl?: string;
+      autoAdvanceAfter?: string;
+      ads?: {
+        doubleclick?: {
+          dataSlot: string;
         };
-        animation?: {
-          image: VisualStoryAnimationFeatureConfig;
-        };
-      }
-    | [
-        {
-          logoAlignment?: string;
-          logoUrl?: string;
-          autoAdvanceAfter?: string;
-          ads?: {
-            doubleclick?: {
-              dataSlot: string;
-            };
-          };
-          animation?: {
-            image: VisualStoryAnimationFeatureConfig;
-            text?: VisualStoryAnimationFeatureConfig;
-          };
-        }
-      ];
+      };
+      animation?: {
+        image: VisualStoryAnimationFeatureConfig;
+        text?: VisualStoryAnimationFeatureConfig;
+      };
+    }
+  ];
   localization?: Localization;
 }
 


### PR DESCRIPTION
# Description

Adding **source** key in **featureConfig > infiniteScroll** for Publisher to choose the source for InfiniteScrolling;
By default , the source will be **collection** , it will be powered by Collection created with slug **amp-infinite-scroll** ;
If the source is **relatedStoriesApi** , then it will take the list from relativeStories API and 
if source is **custom** , then we need to provide an async function for inlineConfig and Remote endpoint & handler

Fixes # (issue-reference)
https://github.com/quintype/ace-planning/issues/678

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

