### PR TITLE
Issue - relative URL for attribute 'src' in 'amp-next-page' is disallowed

### DIFF
--- a/docs-src/tutorials/opts.md
+++ b/docs-src/tutorials/opts.md
@@ -36,7 +36,7 @@ const myOptsObj = {
     infiniteScroll: {
       source: "custom",
       inlineConfig: async getCustomStoryList(){},
-      remoteConfigEndpoint: "/amp/api/infinite-scroll",
+      remoteConfigEndpoint: "amp/api/infinite-scroll",
     }
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.6.0",
+  "version": "2.6.1-afk-amp-rel-url-issue.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.6.0",
+  "version": "2.6.1-afk-amp-rel-url-issue.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/atoms/infinite-scroll/infinite-scroll.tsx
+++ b/src/atoms/infinite-scroll/infinite-scroll.tsx
@@ -17,12 +17,13 @@ export const StyledSeparator = styled.div`
 
 export const InfiniteScrollBase = ({ story, config, children, inlineConfig, ...props }: InfiniteScrollTypes) => {
   const { "story-content-id": storyId } = story;
+  const { "sketches-host": host } = config.publisherConfig;
   const remoteEndPoint = get(
     config,
     ["opts", "featureConfig", "infiniteScroll", "remoteConfigEndpoint"],
-    "/amp/api/v1/amp-infinite-scroll"
+    "amp/api/v1/amp-infinite-scroll"
   );
-  const jsonConfigUrl = `${remoteEndPoint}?story-id=${storyId}`;
+  const jsonConfigUrl = `${host}/${remoteEndPoint}?story-id=${storyId}`;
   const infiniteScrollRender = get(config, ["opts", "render", "infiniteScrollRender"], null);
   const storySeparatorText = get(
     config,


### PR DESCRIPTION
# Description

While Creating an InfiniteScroll feature (- relatedStories/custom stories), we passed the relative URL to src attribute to fix the CORS issue, but the amp library is throwing validation => relative URL for attribute 'src' in 'amp-next-page' is disallowed.;

Fixes # (issue-reference)
https://github.com/quintype/ace-planning/issues/678


## Type of change
revert back to absoluteUrl for src

