### PR TITLE
add height and width to amp-video to remove amp validation errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.6.2",
+  "version": "2.6.3-amp-validator-errors.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.7.2",
+  "version": "2.7.3-amp-validator-errors.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.7.0",
+  "version": "2.7.1-amp-validator-errors.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.7.2",
+  "version": "2.7.3-amp-validator-errors.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.6.2",
+  "version": "2.6.3-amp-validator-errors.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.7.0",
+  "version": "2.7.1-amp-validator-errors.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/atoms/video-web-story/video-web-story.tsx
+++ b/src/atoms/video-web-story/video-web-story.tsx
@@ -13,7 +13,7 @@ export const VideoWebStoryBase = ({ config, videoElement, imageElement }) => {
         <script async={undefined} custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js" />
       </Helmet>
       <amp-story-grid-layer template="fill">
-        <amp-video autoplay="" poster={poster} height="auto" layout="responsive">
+        <amp-video autoplay="" height="720" width="480" poster={poster} layout="responsive">
           <source src={videoUrl} type={`video/${format}`} />
         </amp-video>
       </amp-story-grid-layer>


### PR DESCRIPTION
Reference: https://github.com/quintype/quintype-amp/issues/398