### PR TITLE
Fix: Add fallback to poster images in visual story template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.9.2",
+  "version": "2.9.3-fallback-hero.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.9.3-fallback-hero.0",
+  "version": "2.9.3-fallback-hero.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.9.3-fallback-hero.0",
+  "version": "2.9.3-fallback-hero.1",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.9.2",
+  "version": "2.9.3-fallback-hero.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/atoms/video-web-story/video-web-story.tsx
+++ b/src/atoms/video-web-story/video-web-story.tsx
@@ -3,10 +3,10 @@ import Helmet from "react-helmet";
 import atob from "atob-utf-8";
 import { withConfig } from "../../context";
 
-export const VideoWebStoryBase = ({ config, videoElement, imageElement }) => {
+export const VideoWebStoryBase = ({ config, videoElement, imageElement, heroImage }) => {
   const videoUrl = videoElement && atob(`${videoElement["embed-js"]}`);
   const format = videoUrl.split(".")[3];
-  const poster = imageElement ? `https://${config.publisherConfig["cdn-image"]}/${imageElement["image-s3-key"]}` : null;
+  const poster = imageElement ? `https://${config.publisherConfig["cdn-image"]}/${imageElement["image-s3-key"]}` : `https://${config.publisherConfig["cdn-image"]}/${heroImage["hero-image-s3-key"]}` ;
   return (
     <Fragment>
       <Helmet>

--- a/src/atoms/visual-story/web-story-page-components/web-story-page-components.tsx
+++ b/src/atoms/visual-story/web-story-page-components/web-story-page-components.tsx
@@ -13,8 +13,6 @@ const WebStoryPageComponentsBase = ({ card, config, story }: WebStoryPageCompone
   const textElements = card["story-elements"].filter((el) => el.type === "text" && el.subtype !== "cta");
   const imageElement = card["story-elements"].find((el) => el.type === "image");
   const heroImgSrc = story["hero-image-s3-key"];
-  const heroImgMetadata = story["hero-image-metadata"];
-  const altText = story["hero-image-caption"] || story["hero-image-attribution"] || "";
 
   const videoElement = card["story-elements"].find((el) => el.type === "jsembed");
 
@@ -31,7 +29,7 @@ const WebStoryPageComponentsBase = ({ card, config, story }: WebStoryPageCompone
 
   return (
     <Fragment>
-      {videoElement && <VideoWebStory videoElement={videoElement} imageElement={imageElement} />}
+      {videoElement && <VideoWebStory videoElement={videoElement} imageElement={imageElement} heroImage={heroImgSrc} />}
       {imageElement && !videoElement && (
         <amp-story-grid-layer template="fill">
           <Image
@@ -40,19 +38,6 @@ const WebStoryPageComponentsBase = ({ card, config, story }: WebStoryPageCompone
             metadata={imageElement["image-metadata"]}
             aspectRatio={[480, 640]}
             alt={imageElement.title || imageElement["image-attribution"]}
-            lightbox={false}
-            {...imageAnimation}
-          />
-        </amp-story-grid-layer>
-      )}
-      {!imageElement && videoElement && (
-        <amp-story-grid-layer template="fill">
-          <Image
-            class="qt-amp-visual-story-img"
-            aspectRatio={[480, 640]}
-            alt={altText}
-            slug={heroImgSrc}
-            metadata={heroImgMetadata}
             lightbox={false}
             {...imageAnimation}
           />

--- a/src/atoms/visual-story/web-story-page-components/web-story-page-components.tsx
+++ b/src/atoms/visual-story/web-story-page-components/web-story-page-components.tsx
@@ -12,6 +12,9 @@ const WebStoryPageComponentsBase = ({ card, config, story }: WebStoryPageCompone
   const titleElement = card["story-elements"].find((el) => el.type === "title");
   const textElements = card["story-elements"].filter((el) => el.type === "text" && el.subtype !== "cta");
   const imageElement = card["story-elements"].find((el) => el.type === "image");
+  const heroImgSrc = story["hero-image-s3-key"];
+  const heroImgMetadata = story["hero-image-metadata"];
+  const altText = story["hero-image-caption"] || story["hero-image-attribution"] || "";
 
   const videoElement = card["story-elements"].find((el) => el.type === "jsembed");
 
@@ -42,6 +45,19 @@ const WebStoryPageComponentsBase = ({ card, config, story }: WebStoryPageCompone
           />
         </amp-story-grid-layer>
       )}
+      {!imageElement && videoElement && (
+        <amp-story-grid-layer template="fill">
+          <Image
+            class="qt-amp-visual-story-img"
+            aspectRatio={[480, 640]}
+            alt={altText}
+            slug={heroImgSrc}
+            metadata={heroImgMetadata}
+            lightbox={false}
+            {...imageAnimation}
+          />
+        </amp-story-grid-layer>
+      )}
       {(titleElement || textElements.length || imageElement) && !videoElement && (
         <amp-story-grid-layer template="thirds">
           <TextWrapper>
@@ -54,7 +70,7 @@ const WebStoryPageComponentsBase = ({ card, config, story }: WebStoryPageCompone
                   dangerouslySetInnerHTML={{
                     __html: getFigcaptionText(imageElement.title, imageElement["image-attribution"]) || ""
                   }}
-                />
+                /> 
               )}
             </div>
           </TextWrapper>


### PR DESCRIPTION
# Description

Fix Amp errors if image  element is not adding to visual story template when video element is added. 

Fixes # (issue-reference)

Added fallback as hero image 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Create a visual story, add hero image, add video element first card and publish. 
2. It shouldn't throw any errors and poster should pick up hero image as fallback


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
