### PR TITLE
[feat]: Add support for custom fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.11.0",
+  "version": "2.11.1-custom-fonts.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.11.0",
+  "version": "2.11.1-custom-fonts.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__fixtures__/config.fixture.tsx
+++ b/src/__fixtures__/config.fixture.tsx
@@ -581,7 +581,8 @@ export const ampConfig: AMPConfig = {
     secondary: {
       url: "PT+Serif:400,400italic,700,700italic",
       family: "'PT Serif', sans-serif"
-    }
+    },
+    custom: "https://fonts.googleapis.com/css?family=Tangerine"
   },
   colors: {
     primary: "#294f32",

--- a/src/atoms/fonts/__snapshots__/fonts.test.tsx.snap
+++ b/src/atoms/fonts/__snapshots__/fonts.test.tsx.snap
@@ -22,5 +22,10 @@ exports[`Fonts component Should match snapshot 1`] = `
     href="https://fonts.googleapis.com/css?family=Mukta+Malar:400,400italic,700,700italic&display=swap"
     rel="preload"
   />
+  <link
+    as="style"
+    crossorigin="anonymous"
+    rel="preload"
+  />
 </HelmetWrapper>
 `;

--- a/src/atoms/fonts/fonts.tsx
+++ b/src/atoms/fonts/fonts.tsx
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet";
 import { withStoryAndConfig } from "../../context";
 
 export const FontsBase = ({ config }) => {
-  const { primary, secondary } = config.ampConfig.fonts;
+  const { primary, secondary, custom } = config.ampConfig.fonts;
 
   return (
     <Helmet>
@@ -20,6 +20,7 @@ export const FontsBase = ({ config }) => {
         crossorigin="anonymous"
         href={`https://fonts.googleapis.com/css?family=${secondary.url}&display=swap`}
       />
+      <link rel="preload" as="style" crossorigin="anonymous" href={custom} />
     </Helmet>
   );
 };

--- a/src/atoms/subscriptions/subscriptions-paywall/__snapshots__/subscription-paywall.test.tsx.snap
+++ b/src/atoms/subscriptions/subscriptions-paywall/__snapshots__/subscription-paywall.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`Subscriptions should render subscriptions 1`] = `
           },
         },
         "fonts": Object {
+          "custom": "https://fonts.googleapis.com/css?family=Tangerine",
           "primary": Object {
             "family": "\\"Open Sans\\", sans-serif",
             "url": "Open+Sans:300,400,600,700",

--- a/src/molecules/related-stories/__snapshots__/related-stories.test.tsx.snap
+++ b/src/molecules/related-stories/__snapshots__/related-stories.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`RelatedStories should render default 1`] = `
             },
           },
           "fonts": Object {
+            "custom": "https://fonts.googleapis.com/css?family=Tangerine",
             "primary": Object {
               "family": "\\"Open Sans\\", sans-serif",
               "url": "Open+Sans:300,400,600,700",

--- a/src/templates/generic-story/__snapshots__/generic-story.test.tsx.snap
+++ b/src/templates/generic-story/__snapshots__/generic-story.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`GenericStory Template should render 1`] = `
           },
         },
         "fonts": Object {
+          "custom": "https://fonts.googleapis.com/css?family=Tangerine",
           "primary": Object {
             "family": "\\"Open Sans\\", sans-serif",
             "url": "Open+Sans:300,400,600,700",

--- a/src/templates/live-blog/__snapshots__/live-blog.validation.test.tsx.snap
+++ b/src/templates/live-blog/__snapshots__/live-blog.validation.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`The LiveBlog Default Template should match snapshot 1`] = `
           },
         },
         "fonts": Object {
+          "custom": "https://fonts.googleapis.com/css?family=Tangerine",
           "primary": Object {
             "family": "\\"Open Sans\\", sans-serif",
             "url": "Open+Sans:300,400,600,700",

--- a/src/templates/visual-story/__snapshots__/visual-story.test.tsx.snap
+++ b/src/templates/visual-story/__snapshots__/visual-story.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`visual story template should match snapshot 1`] = `
           },
         },
         "fonts": Object {
+          "custom": "https://fonts.googleapis.com/css?family=Tangerine",
           "primary": Object {
             "family": "\\"Open Sans\\", sans-serif",
             "url": "Open+Sans:300,400,600,700",

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -71,6 +71,7 @@ export interface AMPConfig {
       url: string;
       family: string;
     };
+    custom: string;
   };
   colors: Colors;
   "logo-url": string;


### PR DESCRIPTION
# Description

At present, we support only google fonts by doing this we can support all the origin urls which AMP supports. 
We will Pick up custom font url from amp config that is added in Bold. Settings > configure > amp under Fonts 

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Add custom font url in the custom font field in Bold and check whether its reflecting in the frontend or not

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
