### PR TITLE
[feat]: Add render Prop to Footer Component

### DIFF
--- a/docs-src/tutorials/opts.md
+++ b/docs-src/tutorials/opts.md
@@ -20,6 +20,7 @@ const myOptsObj = {
   },
   render: {
     headerCardRender: ({ story, config }) => <CustHeaderCard story={story} config={config} />,
+    footerRender: ({ story, config }) => <CustFooter story={story} config={config} />,
     infiniteScrollRender: ({ story, config, inlineConfig }) => <CustomInfiniteScroll story={story} config={config} firstFiveStoriesConfig={inlineConfig} />
     // ... other renders
     storyElementRender: {
@@ -49,6 +50,7 @@ const myOptsObj = {
   - `storyElementRender`
   - `relatedStoriesRender`
   - `headerCardRender`
+  - `footerRender`
   - `infiniteScrollRender`
 - `featureConfig` - used to provide config for amp lib features.
 
@@ -154,6 +156,7 @@ For example,
 ampRoutes(app, {
   render: {
     headerCardRender: ({story, config}) => <div>CUSTOM HEADER CARD</div>
+    footerRender: ({story, config}) => <div>CUSTOM FOOTER</div>
     storyElementRender: {
       textElementRender: ({ story, config, element }) => (
         <div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.11.1-footer-render.0",
+  "version": "2.11.1-footer-render.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.11.1-footer-render.1",
+  "version": "2.11.1-footer-render.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.11.0",
+  "version": "2.11.1-footer-render.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.11.0",
+  "version": "2.11.1-footer-render.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.11.1-footer-render.1",
+  "version": "2.11.1-footer-render.2",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.11.1-footer-render.0",
+  "version": "2.11.1-footer-render.1",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/atoms/footer/footer.test.tsx
+++ b/src/atoms/footer/footer.test.tsx
@@ -1,29 +1,29 @@
 import React from "react";
-import { BaseFooter, PoweredBy } from "./footer";
+import { BaseFooter, PoweredBy, DefaultFooter } from "./footer";
 import { shallow } from "enzyme";
 import { Config } from "../../types/config";
 import { config } from "../../../src/__fixtures__";
 
 describe("Footer", () => {
   it("should render", () => {
-    const wrapper = shallow(<BaseFooter />);
+    const wrapper = shallow(<DefaultFooter />);
     expect(wrapper).toMatchSnapshot();
   });
   it("should render children", () => {
     const wrapper = shallow(
-      <BaseFooter>
+      <DefaultFooter>
         <amp-img
           src="https://images.unsplash.com/photo-1558980395-be8a5fcb4251?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60"
           width="400"
           height="300"
           alt="a sample image"
         />
-      </BaseFooter>
+      </DefaultFooter>
     );
     expect(wrapper.find("amp-img").length).toBe(1);
   });
   it("should render powered by quintype when showPoweredByQt attribute is not passed", () => {
-    const wrapper = shallow(<BaseFooter config={config} />);
+    const wrapper = shallow(<DefaultFooter config={config} />);
     expect(wrapper.find(PoweredBy).exists()).toBeTruthy();
   });
   it("should render powered by quintype when showPoweredByQt attribute is passed as a function with truthy value", () => {
@@ -34,7 +34,7 @@ describe("Footer", () => {
       }
     };
 
-    const wrapper = shallow(<BaseFooter config={defaultConfig} />);
+    const wrapper = shallow(<DefaultFooter config={defaultConfig} />);
     expect(wrapper.find(PoweredBy).exists()).toBeTruthy();
   });
   it("should not render powered by quintype when showPoweredByQt attribute is passed as a function with falsy value", () => {
@@ -45,7 +45,7 @@ describe("Footer", () => {
       }
     };
 
-    const wrapper = shallow(<BaseFooter config={defaultConfig} />);
+    const wrapper = shallow(<DefaultFooter config={defaultConfig} />);
     expect(wrapper.find(PoweredBy).exists()).toBeFalsy();
   });
   it("should render powered by quintype when showPoweredByQt attribute is passed as a boolean with truthy value", () => {
@@ -56,7 +56,7 @@ describe("Footer", () => {
       }
     };
 
-    const wrapper = shallow(<BaseFooter config={defaultConfig} />);
+    const wrapper = shallow(<DefaultFooter config={defaultConfig} />);
     expect(wrapper.find(PoweredBy).exists()).toBeTruthy();
   });
   it("should not render powered by quintype when showPoweredByQt attribute is passed as a boolean with falsy value", () => {
@@ -67,7 +67,17 @@ describe("Footer", () => {
       }
     };
 
-    const wrapper = shallow(<BaseFooter config={defaultConfig} />);
+    const wrapper = shallow(<DefaultFooter config={defaultConfig} />);
     expect(wrapper.find(PoweredBy).exists()).toBeFalsy();
+  });
+  it("should call footerRender prop when passed to opts", () => {
+    const footerRender = jest.fn();
+    const modifiedConfig = {
+      ...config,
+      opts: { render: { footerRender } }
+    };
+    const wrapper = shallow(<BaseFooter config={modifiedConfig} />);
+    expect(footerRender.mock.calls.length).toBe(1);
+    expect(wrapper.find(DefaultFooter).length).toBe(0);
   });
 });

--- a/src/atoms/footer/footer.tsx
+++ b/src/atoms/footer/footer.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from "react";
-import styled, { CSSObject, css } from "styled-components";
+import styled, { css } from "styled-components";
 import get from "lodash.get";
 import { FooterTypes } from "./types";
 import { genStyles } from "../../helpers/gen-styles";

--- a/src/atoms/footer/footer.tsx
+++ b/src/atoms/footer/footer.tsx
@@ -28,7 +28,7 @@ const StyledFooter = styled("footer")<FooterTypes>`
   ${(props) => genStyles(baseStyles, props.style, props)}
 `;
 
-const BaseFooter = ({ text, children, style, config }: FooterTypes) => {
+export const DefaultFooter = ({ text, children, style, config }: FooterTypes) => {
   let showPoweredByQt: boolean | ((config) => boolean) = get(
     config,
     ["opts", "featureConfig", "showPoweredByQt"],
@@ -51,6 +51,16 @@ const BaseFooter = ({ text, children, style, config }: FooterTypes) => {
         </Fragment>
       )}
     </StyledFooter>
+  );
+};
+
+const BaseFooter = ({ text, children, style, config  }: FooterTypes) => {
+  const footerRender = get(config, ["opts", "render", "footerRender"], null);
+
+  return footerRender ? (
+    footerRender({ text, children, style, config })
+  ) : (
+    <DefaultFooter text={text} children={children} style={style} config={config} />
   );
 };
 

--- a/src/atoms/footer/footer.tsx
+++ b/src/atoms/footer/footer.tsx
@@ -54,13 +54,20 @@ export const DefaultFooter = ({ text, children, style, config }: FooterTypes) =>
   );
 };
 
-const BaseFooter = ({ text, children, style, config  }: FooterTypes) => {
+const BaseFooter = ({ text, children, style, config, story, collection }: FooterTypes) => {
   const footerRender = get(config, ["opts", "render", "footerRender"], null);
 
   return footerRender ? (
-    footerRender({ text, children, style, config })
+    footerRender({ text, children, style, config, story, collection })
   ) : (
-    <DefaultFooter text={text} children={children} style={style} config={config} />
+    <DefaultFooter
+      text={text}
+      children={children}
+      style={style}
+      config={config}
+      story={story}
+      collection={collection}
+    />
   );
 };
 

--- a/src/atoms/footer/footer.tsx
+++ b/src/atoms/footer/footer.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from "react";
-import styled, { css } from "styled-components";
+import styled, { CSSObject, css } from "styled-components";
 import get from "lodash.get";
 import { FooterTypes } from "./types";
 import { genStyles } from "../../helpers/gen-styles";
@@ -60,18 +60,51 @@ const BaseFooter = ({ text, children, style, config, story, collection }: Footer
   return footerRender ? (
     footerRender({ text, children, style, config, story, collection })
   ) : (
-    <DefaultFooter
-      text={text}
-      children={children}
-      style={style}
-      config={config}
-      story={story}
-      collection={collection}
-    />
+    <DefaultFooter text={text} children={children} style={style} config={config} />
   );
 };
 
 export { BaseFooter };
+
+/**
+ *
+ * Footer component is the footer which comes at the bottom of the page.
+ * The look of the Footer can be changed using the render prop footerRender. In case footerRender is passed in the config,
+ * it is rendered. Otherwise a default Footer is rendered
+ *
+ * ```javascript
+ * import React from "react";
+ * import { AMP } from "@quintype/amp";
+ * import { Layout, Head } = AMP;
+ * const MyCustomFooter = ({ story, config }) => (
+ * <Layout story={story} config={config}>
+ *    <Head>
+ *      <style>{`
+ *        .footerWrapper {
+ *         display: flex;
+ *         align-items: center;
+ *       }
+ *     `}</style
+ *    </Head>
+ *    <p className="footerWrapper">This is my new footer</p>
+ *  </Layout>
+ * )
+ *
+ * ...
+ * ampRoutes(app, {
+ *    footerRender: ({ story, config }) => <MyCustomFooter story={story} config={config} />
+ * })
+ * ...
+ * ```
+ *
+ * @category Atoms
+ * @module Footer
+ * @component
+ * @param {FooterTypes} props
+ * @param {CSSObject} props.style Optional. Used to pass custom styles
+ * @param {string} props.text Optional. Used to add custom text.
+ * @param {(JSX.Element[] | JSX.Element | React.ReactChildren | React.ReactChild)} props.children Optional. If children is passed, children are shown orelse the default powered by text is shown
+ */
 
 const Footer = withConfig(withTheme(BaseFooter));
 export { Footer };

--- a/src/atoms/footer/types.ts
+++ b/src/atoms/footer/types.ts
@@ -1,5 +1,6 @@
 import { CSSObject, DefaultTheme } from "styled-components";
 import { Config } from "../../types/config";
+import { Collection, Story } from "../../types/story";
 
 export interface FooterTypes {
   text?: string;
@@ -8,4 +9,6 @@ export interface FooterTypes {
   showPoweredByQt?: boolean | ((config) => boolean);
   config?: Config;
   theme?: DefaultTheme;
+  story?: Story;
+  collection?: Collection;
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,4 +1,5 @@
 import { FallbackEntitlementProps, ServicesProps, ScoreProps } from "../atoms/subscriptions/types";
+import { FooterTypes } from "../atoms/footer/types";
 import { Story } from "./story";
 
 export interface Config {
@@ -152,6 +153,7 @@ export interface ConfigOpts {
     headerCardRender?: (props: Config) => any;
     relatedStoriesRender?: (props: RelatedStoriesRenderPropTypes) => any;
     infiniteScrollRender?: (props: InfiniteScrollRenderPropTypes) => any;
+    footerRender?: (props: FooterTypes) => any;
     subscriptionRender?: {
       meterRender?: (props: SubscriptionRenderPropTypes) => any;
       LastStoryMeterRender?: (props: SubscriptionRenderPropTypes) => any;


### PR DESCRIPTION
# Description

At present, footer can be customised with only text and background colour. Many clients came up asking for more customisations. So, we decided to add a render prop to footer which will accept component. 

Dependencies # (dependency-issue-reference)
Update framework version to get this change in frontend. 

Documentation # (link to the corresponding documentation changes)
Yes. Documentation needs to updated with new render prop

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
1. Pass a custom component or div to the render prop in frontend app. And check whether it is reflecting it the frontend in place of footer. 
2. If not passed, default footer should render.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
