### PR TITLE
fix: hero image in amp migrated stories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.1",
+  "version": "2.21.2-fix-amp-hero-image.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.1",
+  "version": "2.21.2-fix-amp-hero-image.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,7 +40,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && npm run jest"
+      "pre-commit": "lint-staged"
     }
   },
   "homepage": "https://github.com/quintype/quintype-amp#readme",

--- a/src/molecules/hero-image/hero-image.tsx
+++ b/src/molecules/hero-image/hero-image.tsx
@@ -30,19 +30,20 @@ const StyledFigcaption = styled.div`
 export const HeroImageBase = ({ story, config }: HeroImageBaseTypes) => {
   const metadata: HeroImageMetadata = get(story, "hero-image-metadata", null);
   const slug: string | null = get(story, "hero-image-s3-key", null);
-  if (!slug || !metadata) return null;
+  if (!slug) return null;
 
   const attribution: string | null = get(story, "hero-image-attribution", null);
   const caption: string | null = get(story, "hero-image-caption", null);
   const altText: string | null = get(story, "hero-image-alt-text", null);
   const disableImgPreload: boolean = get(config, ["opts", "optimizeAmpHtml"], true);
+  const defaultDimensions = { height: 675, width: 1200 };
 
   return (
     <>
       <StyledDiv>
         <Image
           data-hero={"true"}
-          metadata={metadata}
+          metadata={metadata || defaultDimensions}
           slug={slug}
           alt={altText || caption || attribution || ""}
           disableImgPreload={disableImgPreload}></Image>


### PR DESCRIPTION
when the `hero-image-metadata` is null from the Story API data, we were returning null. In this PR we have added default dimension for the image to handle this scenerio