### PR TITLE
fix(jsembed): fallback support for non-iframe elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "performant-array-to-tree": "^1.7.1",
         "quintype-js": "^1.2.1",
         "react-helmet": "^5.2.1",
+        "react-is": "^19.1.0",
         "styled-components": "^5.1.1"
       },
       "devDependencies": {
@@ -24329,6 +24330,11 @@
       "peerDependencies": {
         "react": ">= 0.14.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -50242,6 +50248,11 @@
       "requires": {
         "prop-types": "^15.6.1"
       }
+    },
+    "react-is": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.2-test-jsembed.1",
+  "version": "2.21.2-test-jsembed.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.4-test-jsembed.0",
+  "version": "2.21.4-test-jsembed.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.2-test-jsembed.0",
+  "version": "2.21.2-test-jsembed.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.2-fix-amp-hero-image.1",
+  "version": "2.21.2-test-jsembed.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.3",
+  "version": "2.21.4-test-jsembed.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "performant-array-to-tree": "^1.7.1",
     "quintype-js": "^1.2.1",
     "react-helmet": "^5.2.1",
+    "react-is": "^19.1.0",
     "styled-components": "^5.1.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.2-test-jsembed.1",
+  "version": "2.21.2-test-jsembed.2",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.3",
+  "version": "2.21.4-test-jsembed.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.4-test-jsembed.0",
+  "version": "2.21.4-test-jsembed.1",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.2-fix-amp-hero-image.1",
+  "version": "2.21.2-test-jsembed.0",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.21.2-test-jsembed.0",
+  "version": "2.21.2-test-jsembed.1",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/atoms/story-elements/embed/embed.tsx
+++ b/src/atoms/story-elements/embed/embed.tsx
@@ -14,11 +14,18 @@ export const getIframeContent = (str, regex) => {
 };
 
 export const DefaultEmbed = ({ element }: StoryElementProps) => {
+  console.log("element", element);
   const embedData = element["embed-js"] ? atob(element["embed-js"]) : "";
   const src = getIframeContent(embedData, /(?<=src=["']).*?(?=[*"'])/);
   const scrolling = getIframeContent(embedData, /(?<=scrolling=["']).*?(?=[*"'])/);
   const title = element.subtype || element.title || "";
-  return src ? <Iframe src={src} scrolling={scrolling} title={title} /> : null;
+  if (src) {
+    return <Iframe src={src} scrolling={scrolling} title={title} />;
+  } else if (embedData) {
+    console.log("embedData", embedData);
+    return <div dangerouslySetInnerHTML={{ __html: embedData }} />;
+  }
+  return null;
 };
 
 export const getIframeSourceURL = (str: string): string | null => {

--- a/src/atoms/story-elements/embed/embed.tsx
+++ b/src/atoms/story-elements/embed/embed.tsx
@@ -14,7 +14,6 @@ export const getIframeContent = (str, regex) => {
 };
 
 export const DefaultEmbed = ({ element }: StoryElementProps) => {
-  console.log("element", element);
   const embedData = element["embed-js"] ? atob(element["embed-js"]) : "";
   const src = getIframeContent(embedData, /(?<=src=["']).*?(?=[*"'])/);
   const scrolling = getIframeContent(embedData, /(?<=scrolling=["']).*?(?=[*"'])/);
@@ -22,7 +21,6 @@ export const DefaultEmbed = ({ element }: StoryElementProps) => {
   if (src) {
     return <Iframe src={src} scrolling={scrolling} title={title} />;
   } else if (embedData) {
-    console.log("embedData", embedData);
     return <div dangerouslySetInnerHTML={{ __html: embedData }} />;
   }
   return null;

--- a/src/atoms/story-elements/embed/embed.tsx
+++ b/src/atoms/story-elements/embed/embed.tsx
@@ -26,6 +26,9 @@ export const DefaultEmbed = ({ element }: StoryElementProps) => {
     !/\bon\w+=/i.test(embedData) &&
     !/javascript:/i.test(embedData)
   ) {
+    // Ensure embedData does not contain disallowed tags (e.g., <script>, <iframe>, etc.),
+    // inline event handlers (e.g., onclick=, onmouseover=), or javascript: URLs
+    // to prevent XSS and unsafe content injection.
     return <div dangerouslySetInnerHTML={{ __html: embedData }} />;
   }
   return null;

--- a/src/atoms/story-elements/embed/embed.tsx
+++ b/src/atoms/story-elements/embed/embed.tsx
@@ -20,7 +20,12 @@ export const DefaultEmbed = ({ element }: StoryElementProps) => {
   const title = element.subtype || element.title || "";
   if (src) {
     return <Iframe src={src} scrolling={scrolling} title={title} />;
-  } else if (embedData) {
+  } else if (
+    embedData &&
+    !/<(script|iframe|form|style|object|embed|frame|frameset|meta|link|base)[\s>]/i.test(embedData) &&
+    !/\bon\w+=/i.test(embedData) &&
+    !/javascript:/i.test(embedData)
+  ) {
     return <div dangerouslySetInnerHTML={{ __html: embedData }} />;
   }
   return null;

--- a/src/helpers/match-story-element/match-story-element.tsx
+++ b/src/helpers/match-story-element/match-story-element.tsx
@@ -53,6 +53,7 @@ const storyElementsTable = [
   ["jsembed", "tweet", TwitterElement],
   ["jsembed", "vidible-video", VidibleElement],
   ["jsembed", anyType, Embed],
+  ["jsembed", "null", Embed],
   ["polltype", "opinion-poll", Unsupported],
   ["soundcloud-audio", none, Unsupported],
   ["text", "also-read", AlsoRead],


### PR DESCRIPTION
fix: https://github.com/quintype/page-builder/issues/3923
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced embed support to display sanitized raw embed HTML when an iframe source is unavailable.
  * Improved handling of "jsembed" story elements for better compatibility.

* **Chores**
  * Updated package version to 2.21.4-test-jsembed.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->