### PR TITLE
fix enable no follow through bold only in amp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.22.13-no-follow-fix.2",
+  "version": "2.22.13-no-follow-fix.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.22.13-no-follow-fix.3",
+  "version": "2.22.13-no-follow-fix.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.22.13-no-follow-fix.5",
+  "version": "2.22.13-no-follow-fix.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.22.12",
+  "version": "2.22.13-no-follow-fix.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.22.13-no-follow-fix.4",
+  "version": "2.22.13-no-follow-fix.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.22.12",
+  "version": "2.22.13-no-follow-fix.2",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.22.13-no-follow-fix.2",
+  "version": "2.22.13-no-follow-fix.3",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.22.13-no-follow-fix.5",
+  "version": "2.22.13-no-follow-fix.6",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.22.13-no-follow-fix.4",
+  "version": "2.22.13-no-follow-fix.5",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/amp",
-  "version": "2.22.13-no-follow-fix.3",
+  "version": "2.22.13-no-follow-fix.4",
   "description": "Quintype's AMP component library for publisher apps to create amp layouts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/atoms/story-elements/text/text.helpers.test.ts
+++ b/src/atoms/story-elements/text/text.helpers.test.ts
@@ -37,7 +37,7 @@ test("conditionExternalLinks should add target blank on external links without a
   );
 });
 
-test("conditionExternalLinks should not overwrite an existing rel attribute set by the editor", async () => {
+test("conditionExternalLinks should add target blank to external links even when rel is already set by the editor", async () => {
   const dummyText = `<p><a href="https://www.example.com/page" rel="sponsored">Sponsored link</a> and <a href="https://www.other.com/page">external link</a></p>`;
   const dummyConfig = {
     publisherConfig: {
@@ -48,7 +48,7 @@ test("conditionExternalLinks should not overwrite an existing rel attribute set 
 
   const output = conditionExternalLinks({ text: dummyText, config: dummyConfig });
   expect(output).toBe(
-    `<p><a href="https://www.example.com/page" rel="sponsored">Sponsored link</a> and <a href="https://www.other.com/page" target="_blank">external link</a></p>`
+    `<p><a href="https://www.example.com/page" target="_blank" rel="sponsored">Sponsored link</a> and <a href="https://www.other.com/page" target="_blank">external link</a></p>`
   );
 });
 

--- a/src/atoms/story-elements/text/text.helpers.test.ts
+++ b/src/atoms/story-elements/text/text.helpers.test.ts
@@ -4,8 +4,8 @@
 
 import { conditionExternalLinks } from "./text.helpers";
 
-test("conditionExternalLinks should add 'nofollow noopener' and target blank on external links", async () => {
-  const dummyText = `<p><a href="https://www.vikatan.com/a/bc/def">An expert committee</a> set up by ... data.</p><p>The “<a href="https://static.mygov.in/rest/s3fs-public/mygov_159453381955063671.pdf">Report by the Committee </a>” recommends that ... citizens. Lorem <a href="https://sports.vikatan.com/aaaa/bbb/ccc.jpg">ipsum</a> dolor sit <a href="https://cinema.vikatan.com/foo/123" >amet</a>, consectetur <a href="https://www.facebook.com/mark/zucc">adipiscing</a> elit</p>`;
+test("conditionExternalLinks should add target blank on external links without any rel attribute", async () => {
+  const dummyText = `<p><a href="https://www.vikatan.com/a/bc/def">An expert committee</a> set up by ... data.</p><p>The "<a href="https://static.mygov.in/rest/s3fs-public/mygov_159453381955063671.pdf">Report by the Committee </a>" recommends that ... citizens. Lorem <a href="https://sports.vikatan.com/aaaa/bbb/ccc.jpg">ipsum</a> dolor sit <a href="https://cinema.vikatan.com/foo/123" >amet</a>, consectetur <a href="https://www.facebook.com/mark/zucc">adipiscing</a> elit</p>`;
   const dummyConfig = {
     publisherConfig: {
       "sketches-host": "https://www.vikatan.com",
@@ -33,7 +33,22 @@ test("conditionExternalLinks should add 'nofollow noopener' and target blank on 
   };
   const output = conditionExternalLinks({ text: dummyText, config: dummyConfig });
   expect(output).toBe(
-    `<p><a href=\"https://www.vikatan.com/a/bc/def\">An expert committee</a> set up by ... data.</p><p>The “<a href=\"https://static.mygov.in/rest/s3fs-public/mygov_159453381955063671.pdf\" rel=\"nofollow noopener\" target=\"_blank\">Report by the Committee </a>” recommends that ... citizens. Lorem <a href=\"https://sports.vikatan.com/aaaa/bbb/ccc.jpg\">ipsum</a> dolor sit <a href=\"https://cinema.vikatan.com/foo/123\" >amet</a>, consectetur <a href=\"https://www.facebook.com/mark/zucc\" rel=\"nofollow noopener\" target=\"_blank\">adipiscing</a> elit</p>`
+    `<p><a href="https://www.vikatan.com/a/bc/def">An expert committee</a> set up by ... data.</p><p>The "<a href="https://static.mygov.in/rest/s3fs-public/mygov_159453381955063671.pdf" target="_blank">Report by the Committee </a>" recommends that ... citizens. Lorem <a href="https://sports.vikatan.com/aaaa/bbb/ccc.jpg">ipsum</a> dolor sit <a href="https://cinema.vikatan.com/foo/123" >amet</a>, consectetur <a href="https://www.facebook.com/mark/zucc" target="_blank">adipiscing</a> elit</p>`
+  );
+});
+
+test("conditionExternalLinks should not overwrite an existing rel attribute set by the editor", async () => {
+  const dummyText = `<p><a href="https://www.example.com/page" rel="sponsored">Sponsored link</a> and <a href="https://www.other.com/page">external link</a></p>`;
+  const dummyConfig = {
+    publisherConfig: {
+      "sketches-host": "https://www.vikatan.com",
+      domains: []
+    }
+  };
+
+  const output = conditionExternalLinks({ text: dummyText, config: dummyConfig });
+  expect(output).toBe(
+    `<p><a href="https://www.example.com/page" rel="sponsored">Sponsored link</a> and <a href="https://www.other.com/page" target="_blank">external link</a></p>`
   );
 });
 

--- a/src/atoms/story-elements/text/text.helpers.ts
+++ b/src/atoms/story-elements/text/text.helpers.ts
@@ -3,7 +3,7 @@ import { parse } from "node-html-parser";
 
 export const conditionExternalLinks = ({ text, config }) => {
   // finds external links and adds target="_blank" to them
-  // rel (nofollow/noopener) is intentionally omitted — it must be set explicitly by the editor in Bold CMS
+  // rel (nofollow/noopener) is intentionally omitted — it must be set explicitly by the editor in Bold CMS;
 
   const internalHosts: string[] = [];
 
@@ -22,13 +22,10 @@ export const conditionExternalLinks = ({ text, config }) => {
   let accumulator = text;
   anchorsArr.forEach((el) => {
     const href = el.rawAttributes.href || null;
-    const existingRel = el.rawAttributes.rel || null;
-    if (href && !existingRel && regex.test(href)) {
+    const rel = el.rawAttributes.rel || null;
+    if (href && !rel && regex.test(href)) {
       const escapedHref = escapeRegex(href);
-      accumulator = accumulator.replace(
-        new RegExp(`href="${escapedHref}"`),
-        `href="${href}" target="_blank"`
-      );
+      accumulator = accumulator.replace(new RegExp(`href="${escapedHref}"`), `href="${href}" target="_blank"`);
     }
   });
   return accumulator;

--- a/src/atoms/story-elements/text/text.helpers.ts
+++ b/src/atoms/story-elements/text/text.helpers.ts
@@ -2,7 +2,8 @@ import get from "lodash.get";
 import { parse } from "node-html-parser";
 
 export const conditionExternalLinks = ({ text, config }) => {
-  // finds external links and adds rel=”nofollow noopener” target="_blank" to them
+  // finds external links and adds target="_blank" to them
+  // rel (nofollow/noopener) is intentionally omitted — it must be set explicitly by the editor in Bold CMS
 
   const internalHosts: string[] = [];
 
@@ -21,11 +22,12 @@ export const conditionExternalLinks = ({ text, config }) => {
   let accumulator = text;
   anchorsArr.forEach((el) => {
     const href = el.rawAttributes.href || null;
-    if (href && regex.test(href)) {
+    const existingRel = el.rawAttributes.rel || null;
+    if (href && !existingRel && regex.test(href)) {
       const escapedHref = escapeRegex(href);
       accumulator = accumulator.replace(
         new RegExp(`href="${escapedHref}"`),
-        `href="${href}" rel="nofollow noopener" target="_blank"`
+        `href="${href}" target="_blank"`
       );
     }
   });

--- a/src/atoms/story-elements/text/text.helpers.ts
+++ b/src/atoms/story-elements/text/text.helpers.ts
@@ -2,8 +2,7 @@ import get from "lodash.get";
 import { parse } from "node-html-parser";
 
 export const conditionExternalLinks = ({ text, config }) => {
-  // finds external links and adds target="_blank" to them (unless they already have a target set)
-  // rel (nofollow/noopener) is never modified — it must be set explicitly by the editor in Bold CMS;
+  // Adds target="_blank" to external links that do not already specify a target; rel attributes (e.g., nofollow) is not modified and must be configured in Bold CMS.
 
   const internalHosts: string[] = [];
 
@@ -25,7 +24,10 @@ export const conditionExternalLinks = ({ text, config }) => {
     const target = el.rawAttributes.target || null;
     if (href && !target && regex.test(href)) {
       const escapedHref = escapeRegex(href);
-      accumulator = accumulator.replace(new RegExp(`href="${escapedHref}"`), `href="${href}" target="_blank"`);
+      accumulator = accumulator.replace(
+        new RegExp(`href="${escapedHref}"`),
+        `href="${href}" target="_blank"`
+        );
     }
   });
   return accumulator;

--- a/src/atoms/story-elements/text/text.helpers.ts
+++ b/src/atoms/story-elements/text/text.helpers.ts
@@ -2,8 +2,8 @@ import get from "lodash.get";
 import { parse } from "node-html-parser";
 
 export const conditionExternalLinks = ({ text, config }) => {
-  // finds external links and adds target="_blank" to them
-  // rel (nofollow/noopener) is intentionally omitted — it must be set explicitly by the editor in Bold CMS;
+  // finds external links and adds target="_blank" to them (unless they already have a target set)
+  // rel (nofollow/noopener) is never modified — it must be set explicitly by the editor in Bold CMS;
 
   const internalHosts: string[] = [];
 
@@ -22,8 +22,8 @@ export const conditionExternalLinks = ({ text, config }) => {
   let accumulator = text;
   anchorsArr.forEach((el) => {
     const href = el.rawAttributes.href || null;
-    const rel = el.rawAttributes.rel || null;
-    if (href && !rel && regex.test(href)) {
+    const target = el.rawAttributes.target || null;
+    if (href && !target && regex.test(href)) {
       const escapedHref = escapeRegex(href);
       accumulator = accumulator.replace(new RegExp(`href="${escapedHref}"`), `href="${href}" target="_blank"`);
     }

--- a/src/molecules/date/updated/__snapshots__/date-updated.test.tsx.snap
+++ b/src/molecules/date/updated/__snapshots__/date-updated.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DateUpdated should match snapshot 1`] = `
 <Component
-  formattedDate="almost 6 years ago"
+  formattedDate="about 6 years ago"
   prepend="Story Updated:"
 />
 `;


### PR DESCRIPTION
### Related Ticket: https://github.com/quintype/page-builder/issues/4526
### Dependencies:
madrid: https://github.com/quintype/madrid/pull/5970
quintype-node-framework: https://github.com/quintype/quintype-node-framework/pull/484